### PR TITLE
Allow for later versions of numpy. Update the docs. Drop python3.8

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -13,13 +13,11 @@ jobs:
       matrix:
         os_dist:
           # linux
-          - {os: ubuntu-latest, dist: cp38-manylinux_x86_64}
           - {os: ubuntu-latest, dist: cp39-manylinux_x86_64}
           - {os: ubuntu-latest, dist: cp310-manylinux_x86_64}
           - {os: ubuntu-latest, dist: cp311-manylinux_x86_64}
           - {os: ubuntu-latest, dist: cp312-manylinux_x86_64}
           # macos
-          - {os: macos-latest, dist: cp38-macosx_arm64, macosarch: arm64}
           - {os: macos-latest, dist: cp39-macosx_arm64, macosarch: arm64}
           - {os: macos-latest, dist: cp310-macosx_arm64, macosarch: arm64}
           - {os: macos-latest, dist: cp311-macosx_arm64, macosarch: arm64}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ We also added ZX-decomposition which can be used in Qiskit (you need it to insta
 
 ```pycon
 >>> from pauli_lcu.decomposition import pauli_coefficients_xz_phase
->>> pauli_coefficients_xz_phase(matrix)
 >>> x, z, phase = pauli_coefficients_xz_phase(matrix)
 >>> x 
 array([[0],
@@ -116,4 +115,4 @@ PauliList(['I', 'Z', 'X', 'Y'])
 
 If you find this package useful please cite our paper:
 
-Timothy N. Georges, Bjorn K. Berntson, Christoph Sünderhauf, and Aleksei V. Ivanov, _Pauli Decomposition via the Fast Walsh-Hadamard Transform_, https://doi.org/10.48550/arXiv.2408.06206, (2024).
+Timothy N. Georges, Bjorn K. Berntson, Christoph Sünderhauf, and Aleksei V. Ivanov, _Pauli Decomposition via the Fast Walsh-Hadamard Transform_, New J. Phys. 27 033004 (2025), https://doi.org/10.1088/1367-2630/adb44d.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["setuptools>=61.0", "numpy<2.0", "pytest"]
+requires = ["setuptools>=61.0", "numpy", "pytest"]
 build-backend = "setuptools.build_meta"
 
 [project]
 dependencies = [
-  "numpy<2.0", "pytest"
+  "numpy", "pytest"
 ]
 name = "pauli_lcu"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="Aleksei Ivanov", email="aleksei.ivanov@riverlane.com" },
   { name="Christoph Sunderhauf", email="christoph.sunderhauf@riverlane.com" }
@@ -15,7 +15,7 @@ authors = [
 
 description = "Decomposition of a matrix into Pauli strings"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
should close #10 